### PR TITLE
Escape xml strings

### DIFF
--- a/lib/dynamics_crm.rb
+++ b/lib/dynamics_crm.rb
@@ -42,6 +42,7 @@ require 'mimemagic'
 require 'curl'
 require 'securerandom'
 require 'date'
+require 'cgi'
 
 module DynamicsCRM
 

--- a/lib/dynamics_crm/xml/attributes.rb
+++ b/lib/dynamics_crm/xml/attributes.rb
@@ -66,6 +66,9 @@ module DynamicsCRM
             type = get_type(key, value)
           end
 
+          # escape strings to avoid xml parsing errors
+          value = CGI.escapeHTML(value) if type == "string"
+
           xml << build_xml(key, value, type)
         end
 


### PR DESCRIPTION
Escape xml strings to avoid errors when parsing illegal characters (&, <, >)