### PR TITLE
Add `*` to XPath query expression on local-name

### DIFF
--- a/lib/dynamics_crm/client.rb
+++ b/lib/dynamics_crm/client.rb
@@ -79,7 +79,7 @@ module DynamicsCRM
 
       document = REXML::Document.new(soap_response)
       # Check for Fault
-      fault_xml = document.get_elements("//[local-name() = 'Fault']")
+      fault_xml = document.get_elements("//*[local-name() = 'Fault']")
       raise XML::Fault.new(fault_xml) if fault_xml.any?
 
       if on_premise?
@@ -103,7 +103,7 @@ module DynamicsCRM
           @security_token0 = cipher_values[0].text
           @security_token1 = cipher_values[1].text
           # Use local-name() to ignore namespace.
-          @key_identifier = document.get_elements("//[local-name() = 'KeyIdentifier']").first.text
+          @key_identifier = document.get_elements("//*[local-name() = 'KeyIdentifier']").first.text
         else
           raise RuntimeError.new(soap_response)
         end

--- a/lib/dynamics_crm/response/result.rb
+++ b/lib/dynamics_crm/response/result.rb
@@ -7,7 +7,7 @@ module DynamicsCRM
       def initialize(xml)
         @document = REXML::Document.new(xml)
 
-        fault_xml = @document.get_elements("//[local-name() = 'Fault']")
+        fault_xml = @document.get_elements("//*[local-name() = 'Fault']")
         raise XML::Fault.new(fault_xml) if fault_xml.any?
 
         @result_response = @document.get_elements("//#{response_element}").first

--- a/lib/dynamics_crm/xml/fault.rb
+++ b/lib/dynamics_crm/xml/fault.rb
@@ -12,12 +12,12 @@ module DynamicsCRM
           fault_xml = fault_xml.first
         end
         # REXL::Element
-        @code = fault_xml.get_text("//[local-name() = 'Code']/[local-name() = 'Value']")
-        @subcode = fault_xml.get_text("//[local-name() = 'Code']/[local-name() = 'Subcode']/[local-name() = 'Value']")
-        @reason = fault_xml.get_text("//[local-name() = 'Reason']/[local-name() = 'Text']")
+        @code = fault_xml.get_text("//*[local-name() = 'Code']/[local-name() = 'Value']")
+        @subcode = fault_xml.get_text("//*[local-name() = 'Code']/[local-name() = 'Subcode']/[local-name() = 'Value']")
+        @reason = fault_xml.get_text("//*[local-name() = 'Reason']/[local-name() = 'Text']")
 
         @detail = {}
-        detail_fragment = fault_xml.get_elements("//[local-name() = 'Detail']").first
+        detail_fragment = fault_xml.get_elements("//*[local-name() = 'Detail']").first
         if detail_fragment
           fault_type = detail_fragment.elements.first
           @detail[:type] = fault_type.name

--- a/spec/lib/xml/fault_spec.rb
+++ b/spec/lib/xml/fault_spec.rb
@@ -7,7 +7,7 @@ describe DynamicsCRM::XML::Fault do
     context "receiver fault" do
       subject {
         document = REXML::Document.new(fixture('receiver_fault'))
-        fault = document.get_elements("//[local-name() = 'Fault']")
+        fault = document.get_elements("//*[local-name() = 'Fault']")
         DynamicsCRM::XML::Fault.new(fault)
       }
 
@@ -23,7 +23,7 @@ describe DynamicsCRM::XML::Fault do
 
       subject {
         document = REXML::Document.new(fixture('sender_fault'))
-        fault = document.get_elements("//[local-name() = 'Fault']")
+        fault = document.get_elements("//*[local-name() = 'Fault']")
         DynamicsCRM::XML::Fault.new(fault)
       }
 


### PR DESCRIPTION
Add `*` element in all local-name function calls via XPath, to work with ReXML in recent Ruby versions. During further research, we've noted that XPath standard was changed and the previous query (without the asterisk) was not valid anymore. Hence, we're updating it.

The error that was outputted in Ruby 2.7:
![image](https://user-images.githubusercontent.com/9268166/116116813-778cb900-a6b3-11eb-9260-d4ff9a9d0590.png)
